### PR TITLE
XRBK macro: use full paths when deriving traits

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -6,12 +6,7 @@ extern crate self as xrb;
 
 use bytes::Buf;
 use derive_more::{From, Into};
-use xrbk::{
-	ConstantX11Size,
-	ReadResult,
-	ReadableWithContext,
-	Wrapper,
-};
+use xrbk::{ConstantX11Size, ReadResult, ReadableWithContext, Wrapper};
 use xrbk_macro::{derive_xrb, new, unwrap, ConstantX11Size, Readable, Writable, X11Size};
 
 pub mod atom;

--- a/src/common.rs
+++ b/src/common.rs
@@ -9,11 +9,8 @@ use derive_more::{From, Into};
 use xrbk::{
 	ConstantX11Size,
 	ReadResult,
-	Readable,
 	ReadableWithContext,
 	Wrapper,
-	Writable,
-	X11Size,
 };
 use xrbk_macro::{derive_xrb, new, unwrap, ConstantX11Size, Readable, Writable, X11Size};
 

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -8,7 +8,7 @@
 )]
 
 use derive_more::{From, Into};
-use xrbk::{Readable, Writable, X11Size};
+use xrbk::{X11Size};
 use xrbk_macro::{derive_xrb, new, unwrap, Readable, Writable, X11Size};
 
 use crate::{mask::EventMask, BackingStores, Color, Colormap, Keycode, String8, VisualId, Window};

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -8,7 +8,7 @@
 )]
 
 use derive_more::{From, Into};
-use xrbk::{X11Size};
+use xrbk::X11Size;
 use xrbk_macro::{derive_xrb, new, unwrap, Readable, Writable, X11Size};
 
 use crate::{mask::EventMask, BackingStores, Color, Colormap, Keycode, String8, VisualId, Window};

--- a/src/x11/event.rs
+++ b/src/x11/event.rs
@@ -27,7 +27,7 @@ use crate::{
 
 use bitflags::bitflags;
 use bytes::Buf;
-use xrbk::{ConstantX11Size, ReadResult, Readable, ReadableWithContext, Writable, X11Size};
+use xrbk::{ConstantX11Size, ReadResult, Readable, ReadableWithContext, X11Size};
 
 use xrbk_macro::{derive_xrb, ConstantX11Size, Readable, Writable, X11Size};
 extern crate self as xrb;

--- a/xrbk_macro/src/definition/expansion/readable.rs
+++ b/xrbk_macro/src/definition/expansion/readable.rs
@@ -39,27 +39,30 @@ impl Struct {
 			}
 		});
 
-		tokens.append_tokens({
-			quote_spanned!(trait_path.span()=>
-				#[automatically_derived]
-				impl #impl_generics #trait_path for #ident #type_generics #where_clause {
-					#[allow(clippy::items_after_statements, clippy::trivially_copy_pass_by_ref, clippy::needless_borrow, clippy::identity_op)]
-					fn read_from(
-						buf: &mut impl ::xrbk::Buf,
-					) -> Result<Self, ::xrbk::ReadError> {
-						// Declare a x11_size variable if it is going to be
-						// used in an infer unused bytes element.
-						#declare_x11_size
+		tokens.append_tokens(quote_spanned!(trait_path.span()=>
+			#[automatically_derived]
+			impl #impl_generics ::xrbk::Readable for #ident #type_generics #where_clause {
+				#[allow(
+					clippy::items_after_statements,
+					clippy::trivially_copy_pass_by_ref,
+					clippy::needless_borrow,
+					clippy::identity_op,
+				)]
+				fn read_from(
+					buf: &mut impl ::xrbk::Buf,
+				) -> Result<Self, ::xrbk::ReadError> {
+					// Declare a x11_size variable if it is going to be
+					// used in an infer unused bytes element.
+					#declare_x11_size
 
-						// Read each element.
-						#reads
+					// Read each element.
+					#reads
 
-						// Construct and return `Self`.
-						Ok(Self #cons)
-					}
+					// Construct and return `Self`.
+					Ok(Self #cons)
 				}
-			)
-		});
+			}
+		));
 	}
 }
 
@@ -106,33 +109,36 @@ impl Request {
 			Some(quote_spanned!(trait_path.span()=> buf.advance(1);))
 		};
 
-		tokens.append_tokens({
-			quote_spanned!(trait_path.span()=>
-				#[automatically_derived]
-				impl #impl_generics #trait_path for #ident #type_generics #where_clause {
-					#[allow(clippy::items_after_statements, clippy::trivially_copy_pass_by_ref, clippy::needless_borrow, clippy::identity_op)]
-					fn read_from(
-						buf: &mut impl ::xrbk::Buf,
-					) -> Result<Self, ::xrbk::ReadError> {
-						#declare_x11_size
+		tokens.append_tokens(quote_spanned!(trait_path.span()=>
+			#[automatically_derived]
+			impl #impl_generics ::xrbk::Readable for #ident #type_generics #where_clause {
+				#[allow(
+					clippy::items_after_statements,
+					clippy::trivially_copy_pass_by_ref,
+					clippy::needless_borrow,
+					clippy::identity_op,
+				)]
+				fn read_from(
+					buf: &mut impl ::xrbk::Buf,
+				) -> Result<Self, ::xrbk::ReadError> {
+					#declare_x11_size
 
-						// If there is a metabyte element, read it, if not and
-						// there is no minor opcode, skip one byte. If there
-						// is a minor opcode, do nothing - it has already been
-						// read.
-						#metabyte
-						// Read the request's length.
-						let length = buf.get_u16();
+					// If there is a metabyte element, read it, if not and
+					// there is no minor opcode, skip one byte. If there
+					// is a minor opcode, do nothing - it has already been
+					// read.
+					#metabyte
+					// Read the request's length.
+					let length = buf.get_u16();
 
-						// Read other elements.
-						#reads
+					// Read other elements.
+					#reads
 
-						// Construct and return Self.
-						Ok(Self #cons)
-					}
+					// Construct and return Self.
+					Ok(Self #cons)
 				}
-			)
-		});
+			}
+		));
 	}
 }
 
@@ -178,32 +184,35 @@ impl Reply {
 			_ => panic!("replies must have a sequence field"),
 		};
 
-		tokens.append_tokens({
-			quote_spanned!(trait_path.span()=>
-				#[automatically_derived]
-				impl #impl_generics #trait_path for #ident #type_generics #where_clause {
-					#[allow(clippy::items_after_statements, clippy::trivially_copy_pass_by_ref, clippy::needless_borrow, clippy::identity_op)]
-					fn read_from(
-						buf: &mut impl ::xrbk::Buf,
-					) -> Result<Self, ::xrbk::ReadError> {
-						#declare_x11_size
+		tokens.append_tokens(quote_spanned!(trait_path.span()=>
+			#[automatically_derived]
+			impl #impl_generics ::xrbk::Readable for #ident #type_generics #where_clause {
+				#[allow(
+					clippy::items_after_statements,
+					clippy::trivially_copy_pass_by_ref,
+					clippy::needless_borrow,
+					clippy::identity_op,
+				)]
+				fn read_from(
+					buf: &mut impl ::xrbk::Buf,
+				) -> Result<Self, ::xrbk::ReadError> {
+					#declare_x11_size
 
-						// Metabyte position
-						#metabyte
-						// Sequence field
-						let #sequence = buf.get_u16();
-						// Length
-						let length = buf.get_u32();
+					// Metabyte position
+					#metabyte
+					// Sequence field
+					let #sequence = buf.get_u16();
+					// Length
+					let length = buf.get_u32();
 
-						// Other elements
-						#reads
+					// Other elements
+					#reads
 
-						// Construct and return Self.
-						Ok(Self #cons)
-					}
+					// Construct and return Self.
+					Ok(Self #cons)
 				}
-			)
-		});
+			}
+		));
 	}
 }
 
@@ -262,30 +271,33 @@ impl Event {
 			None
 		};
 
-		tokens.append_tokens({
-			quote_spanned!(trait_path.span()=>
-				#[automatically_derived]
-				impl #impl_generics #trait_path for #ident #type_generics #where_clause {
-					#[allow(clippy::items_after_statements, clippy::trivially_copy_pass_by_ref, clippy::needless_borrow, clippy::identity_op)]
-					fn read_from(
-						buf: &mut impl ::xrbk::Buf,
-					) -> Result<Self, ::xrbk::ReadError> {
-						#declare_x11_size
+		tokens.append_tokens(quote_spanned!(trait_path.span()=>
+			#[automatically_derived]
+			impl #impl_generics ::xrbk::Readable for #ident #type_generics #where_clause {
+				#[allow(
+					clippy::items_after_statements,
+					clippy::trivially_copy_pass_by_ref,
+					clippy::needless_borrow,
+					clippy::identity_op,
+				)]
+				fn read_from(
+					buf: &mut impl ::xrbk::Buf,
+				) -> Result<Self, ::xrbk::ReadError> {
+					#declare_x11_size
 
-						// Metabyte position
-						#metabyte
-						// Sequence field
-						#sequence
+					// Metabyte position
+					#metabyte
+					// Sequence field
+					#sequence
 
-						// Other elements
-						#reads
+					// Other elements
+					#reads
 
-						// Construct and return Self.
-						Ok(Self #cons)
-					}
+					// Construct and return Self.
+					Ok(Self #cons)
 				}
-			)
-		});
+			}
+		));
 	}
 }
 
@@ -305,23 +317,21 @@ impl Enum {
 				if let Some((_, expr)) = &variant.discriminant {
 					let ident = format_ident!("discrim_{}", variant.ident);
 
-					tokens.append_tokens({
-						quote_spanned!(trait_path.span()=>
-							// Isolate the discriminant's expression in a
-							// function so that it doesn't have access to
-							// identifiers used in the surrounding generated
-							// code.
-							#[allow(non_snake_case)]
-							fn #ident() -> #discrim_type {
-								(#expr) as #discrim_type
-							}
+					tokens.append_tokens(quote_spanned!(trait_path.span()=>
+						// Isolate the discriminant's expression in a
+						// function so that it doesn't have access to
+						// identifiers used in the surrounding generated
+						// code.
+						#[allow(non_snake_case)]
+						fn #ident() -> #discrim_type {
+							(#expr) as #discrim_type
+						}
 
-							// Call the discriminant's function just once and
-							// store it in a variable for later use.
-							#[allow(non_snake_case)]
-							let #ident = #ident();
-						)
-					});
+						// Call the discriminant's function just once and
+						// store it in a variable for later use.
+						#[allow(non_snake_case)]
+						let #ident = #ident();
+					));
 				}
 			}
 		});
@@ -364,17 +374,15 @@ impl Enum {
 					}
 				});
 
-				tokens.append_tokens({
-					quote_spanned!(trait_path.span()=>
-						discrim if discrim == #discrim => {
-							#declare_x11_size
+				tokens.append_tokens(quote_spanned!(trait_path.span()=>
+					discrim if discrim == #discrim => {
+						#declare_x11_size
 
-							#reads
+						#reads
 
-							Ok(Self::#ident #cons)
-						},
-					)
-				});
+						Ok(Self::#ident #cons)
+					},
+				));
 
 				quote_spanned!(trait_path.span()=> /* discrim */ + 1).to_tokens(&mut discrim);
 			}
@@ -384,34 +392,32 @@ impl Enum {
 			<#discrim_type as ::xrbk::Readable>
 		);
 
-		tokens.append_tokens({
-			quote_spanned!(trait_path.span()=>
-				#[automatically_derived]
-				impl #impl_generics #trait_path for #ident #type_generics #where_clause {
-					#[allow(
-						clippy::items_after_statements,
-						clippy::trivially_copy_pass_by_ref,
-						clippy::needless_borrow,
-						clippy::identity_op,
-						clippy::unnecessary_cast,
-					)]
-					fn read_from(
-						buf: &mut impl ::xrbk::Buf,
-					) -> Result<Self, ::xrbk::ReadError> {
-						// Define functions and variables for variants which
-						// have custom discriminant expressions.
-						#discriminants
+		tokens.append_tokens(quote_spanned!(trait_path.span()=>
+			#[automatically_derived]
+			impl #impl_generics ::xrbk::Readable for #ident #type_generics #where_clause {
+				#[allow(
+					clippy::items_after_statements,
+					clippy::trivially_copy_pass_by_ref,
+					clippy::needless_borrow,
+					clippy::identity_op,
+					clippy::unnecessary_cast,
+				)]
+				fn read_from(
+					buf: &mut impl ::xrbk::Buf,
+				) -> Result<Self, ::xrbk::ReadError> {
+					// Define functions and variables for variants which
+					// have custom discriminant expressions.
+					#discriminants
 
-						match #discrim_type::read_from(buf)? {
-							#arms
+					match #discrim_type::read_from(buf)? {
+						#arms
 
-							other_discrim => Err(
-								::xrbk::ReadError::UnrecognizedDiscriminant(other_discrim as usize),
-							),
-						}
+						other_discrim => Err(
+							::xrbk::ReadError::UnrecognizedDiscriminant(other_discrim as usize),
+						),
 					}
 				}
-			)
-		});
+			}
+		));
 	}
 }

--- a/xrbk_macro/src/definition/expansion/writable.rs
+++ b/xrbk_macro/src/definition/expansion/writable.rs
@@ -404,7 +404,7 @@ impl Enum {
 
 		tokens.append_tokens(quote_spanned!(trait_path.span()=>
 			#[automatically_derived]
-			impl #impl_generics ::xrbk::Writable #ident #type_generics #where_clause {
+			impl #impl_generics ::xrbk::Writable for #ident #type_generics #where_clause {
 				#[allow(
 					clippy::items_after_statements,
 					clippy::trivially_copy_pass_by_ref,

--- a/xrbk_macro/src/definition/expansion/writable.rs
+++ b/xrbk_macro/src/definition/expansion/writable.rs
@@ -36,26 +36,29 @@ impl Struct {
 			}
 		});
 
-		tokens.append_tokens({
-			quote_spanned!(trait_path.span()=>
-				#[automatically_derived]
-				impl #impl_generics #trait_path for #ident #type_generics #where_clause {
-					#[allow(clippy::items_after_statements, clippy::trivially_copy_pass_by_ref, clippy::needless_borrow, clippy::identity_op)]
-					fn write_to(
-						&self,
-						buf: &mut impl ::xrbk::BufMut,
-					) -> Result<(), ::xrbk::WriteError> {
-						#declare_x11_size
-						// Destructure the struct's fields, if any.
-						let Self #pat = self;
+		tokens.append_tokens(quote_spanned!(trait_path.span()=>
+			#[automatically_derived]
+			impl #impl_generics ::xrbk::Writable for #ident #type_generics #where_clause {
+				#[allow(
+					clippy::items_after_statements,
+					clippy::trivially_copy_pass_by_ref,
+					clippy::needless_borrow,
+					clippy::identity_op,
+				)]
+				fn write_to(
+					&self,
+					buf: &mut impl ::xrbk::BufMut,
+				) -> Result<(), ::xrbk::WriteError> {
+					#declare_x11_size
+					// Destructure the struct's fields, if any.
+					let Self #pat = self;
 
-						#writes
+					#writes
 
-						Ok(())
-					}
+					Ok(())
 				}
-			)
-		});
+			}
+		));
 	}
 }
 
@@ -104,34 +107,37 @@ impl Request {
 			)
 		};
 
-		tokens.append_tokens({
-			quote_spanned!(trait_path.span()=>
-				#[automatically_derived]
-				impl #impl_generics #trait_path for #ident #type_generics #where_clause {
-					#[allow(clippy::items_after_statements, clippy::trivially_copy_pass_by_ref, clippy::needless_borrow, clippy::identity_op)]
-					fn write_to(
-						&self,
-						buf: &mut impl ::xrbk::BufMut,
-					) -> Result<(), ::xrbk::WriteError> {
-						#declare_x11_size
-						// Destructure the request struct's fields, if any.
-						let Self #pat = self;
+		tokens.append_tokens(quote_spanned!(trait_path.span()=>
+			#[automatically_derived]
+			impl #impl_generics ::xrbk::Writable for #ident #type_generics #where_clause {
+				#[allow(
+					clippy::items_after_statements,
+					clippy::trivially_copy_pass_by_ref,
+					clippy::needless_borrow,
+					clippy::identity_op,
+				)]
+				fn write_to(
+					&self,
+					buf: &mut impl ::xrbk::BufMut,
+				) -> Result<(), ::xrbk::WriteError> {
+					#declare_x11_size
+					// Destructure the request struct's fields, if any.
+					let Self #pat = self;
 
-						// Major opcode
-						buf.put_u8(<Self as xrb::message::Request>::MAJOR_OPCODE);
-						// Metabyte position
-						#metabyte
-						// Length
-						buf.put_u16(<Self as xrb::message::Request>::length(&self));
+					// Major opcode
+					buf.put_u8(<Self as xrb::message::Request>::MAJOR_OPCODE);
+					// Metabyte position
+					#metabyte
+					// Length
+					buf.put_u16(<Self as xrb::message::Request>::length(&self));
 
-						// Other elements
-						#writes
+					// Other elements
+					#writes
 
-						Ok(())
-					}
+					Ok(())
 				}
-			)
-		});
+			}
+		));
 	}
 }
 
@@ -181,36 +187,39 @@ impl Reply {
 			_ => panic!("replies must have a sequence field"),
 		};
 
-		tokens.append_tokens({
-			quote_spanned!(trait_path.span()=>
-				#[automatically_derived]
-				impl #impl_generics #trait_path for #ident #type_generics #where_clause {
-					#[allow(clippy::items_after_statements, clippy::trivially_copy_pass_by_ref, clippy::needless_borrow, clippy::identity_op)]
-					fn write_to(
-						&self,
-						buf: &mut impl ::xrbk::BufMut,
-					) -> Result<(), ::xrbk::WriteError> {
-						#declare_x11_size
-						// Destructure the reply struct's fields, if any.
-						let Self #pat = self;
+		tokens.append_tokens(quote_spanned!(trait_path.span()=>
+			#[automatically_derived]
+			impl #impl_generics ::xrbk::Writable for #ident #type_generics #where_clause {
+				#[allow(
+					clippy::items_after_statements,
+					clippy::trivially_copy_pass_by_ref,
+					clippy::needless_borrow,
+					clippy::identity_op,
+				)]
+				fn write_to(
+					&self,
+					buf: &mut impl ::xrbk::BufMut,
+				) -> Result<(), ::xrbk::WriteError> {
+					#declare_x11_size
+					// Destructure the reply struct's fields, if any.
+					let Self #pat = self;
 
-						// `1` - indicates this is a reply
-						buf.put_u8(1);
-						// Metabyte position
-						#metabyte
-						// Sequence field
-						buf.put_u16(#sequence);
-						// Length
-						buf.put_u32(<Self as xrb::message::Reply>::length(&self));
+					// `1` - indicates this is a reply
+					buf.put_u8(1);
+					// Metabyte position
+					#metabyte
+					// Sequence field
+					buf.put_u16(#sequence);
+					// Length
+					buf.put_u32(<Self as xrb::message::Reply>::length(&self));
 
-						// Other elements
-						#writes
+					// Other elements
+					#writes
 
-						Ok(())
-					}
+					Ok(())
 				}
-			)
-		});
+			}
+		));
 	}
 }
 
@@ -269,34 +278,37 @@ impl Event {
 			None
 		};
 
-		tokens.append_tokens({
-			quote_spanned!(trait_path.span()=>
-				#[automatically_derived]
-				impl #impl_generics #trait_path for #ident #type_generics #where_clause {
-					#[allow(clippy::items_after_statements, clippy::trivially_copy_pass_by_ref, clippy::needless_borrow, clippy::identity_op)]
-					fn write_to(
-						&self,
-						buf: &mut impl ::xrbk::BufMut,
-					) -> Result<(), ::xrbk::WriteError> {
-						#declare_x11_size
-						// Destructure the event struct's fields, if any.
-						let Self #pat = self;
+		tokens.append_tokens(quote_spanned!(trait_path.span()=>
+			#[automatically_derived]
+			impl #impl_generics ::xrbk::Writable for #ident #type_generics #where_clause {
+				#[allow(
+					clippy::items_after_statements,
+					clippy::trivially_copy_pass_by_ref,
+					clippy::needless_borrow,
+					clippy::identity_op,
+				)]
+				fn write_to(
+					&self,
+					buf: &mut impl ::xrbk::BufMut,
+				) -> Result<(), ::xrbk::WriteError> {
+					#declare_x11_size
+					// Destructure the event struct's fields, if any.
+					let Self #pat = self;
 
-						// Event code
-						buf.put_u8(<Self as xrb::message::Event>::CODE);
-						// Metabyte position
-						#metabyte
-						// Sequence field
-						#sequence
+					// Event code
+					buf.put_u8(<Self as xrb::message::Event>::CODE);
+					// Metabyte position
+					#metabyte
+					// Sequence field
+					#sequence
 
-						// Other elements
-						#writes
+					// Other elements
+					#writes
 
-						Ok(())
-					}
+					Ok(())
 				}
-			)
-		});
+			}
+		));
 	}
 }
 
@@ -316,23 +328,21 @@ impl Enum {
 				if let Some((_, expr)) = &variant.discriminant {
 					let ident = format_ident!("discrim_{}", variant.ident);
 
-					tokens.append_tokens({
-						quote_spanned!(trait_path.span()=>
-							// Isolate the discriminant's expression in a
-							// function so that it doesn't have access to
-							// identifiers used in the surrounding generated
-							// code.
-							#[allow(non_snake_case)]
-							fn #ident() -> #discrim_type {
-								(#expr) as #discrim_type
-							}
+					tokens.append_tokens(quote_spanned!(trait_path.span()=>
+						// Isolate the discriminant's expression in a
+						// function so that it doesn't have access to
+						// identifiers used in the surrounding generated
+						// code.
+						#[allow(non_snake_case)]
+						fn #ident() -> #discrim_type {
+							(#expr) as #discrim_type
+						}
 
-							// Call the discriminant's function just once and
-							// store it in a variable for later use.
-							#[allow(non_snake_case)]
-							let #ident = #ident();
-						)
-					});
+						// Call the discriminant's function just once and
+						// store it in a variable for later use.
+						#[allow(non_snake_case)]
+						let #ident = #ident();
+					));
 				}
 			}
 		});
@@ -392,34 +402,32 @@ impl Enum {
 			}
 		});
 
-		tokens.append_tokens({
-			quote_spanned!(trait_path.span()=>
-				#[automatically_derived]
-				impl #impl_generics #trait_path for #ident #type_generics #where_clause {
-					#[allow(
-						clippy::items_after_statements,
-						clippy::trivially_copy_pass_by_ref,
-						clippy::needless_borrow,
-						clippy::identity_op,
-						clippy::cast_possible_truncation,
-						clippy::unnecessary_cast,
-					)]
-					fn write_to(
-						&self,
-						buf: &mut impl ::xrbk::BufMut,
-					) -> Result<(), ::xrbk::WriteError> {
-						// Define functions and variables for variants which
-						// have custom discriminant expressions.
-						#discriminants
+		tokens.append_tokens(quote_spanned!(trait_path.span()=>
+			#[automatically_derived]
+			impl #impl_generics ::xrbk::Writable #ident #type_generics #where_clause {
+				#[allow(
+					clippy::items_after_statements,
+					clippy::trivially_copy_pass_by_ref,
+					clippy::needless_borrow,
+					clippy::identity_op,
+					clippy::cast_possible_truncation,
+					clippy::unnecessary_cast,
+				)]
+				fn write_to(
+					&self,
+					buf: &mut impl ::xrbk::BufMut,
+				) -> Result<(), ::xrbk::WriteError> {
+					// Define functions and variables for variants which
+					// have custom discriminant expressions.
+					#discriminants
 
-						match self {
-							#arms
-						}
-
-						Ok(())
+					match self {
+						#arms
 					}
+
+					Ok(())
 				}
-			)
-		});
+			}
+		));
 	}
 }

--- a/xrbk_macro/src/definition/expansion/x11_size.rs
+++ b/xrbk_macro/src/definition/expansion/x11_size.rs
@@ -26,25 +26,28 @@ impl Struct {
 			}
 		});
 
-		tokens.append_tokens({
-			quote_spanned!(trait_path.span()=>
-				#[automatically_derived]
-				impl #impl_generics #trait_path for #ident #type_generics #where_clause {
-					#[allow(clippy::items_after_statements, clippy::trivially_copy_pass_by_ref, clippy::needless_borrow, clippy::identity_op)]
-					fn x11_size(&self) -> usize {
-						let mut size: usize = 0;
-						// Destructure the struct's fields, if any.
-						let Self #pat = self;
+		tokens.append_tokens(quote_spanned!(trait_path.span()=>
+			#[automatically_derived]
+			impl #impl_generics ::xrbk::X11Size #ident #type_generics #where_clause {
+				#[allow(
+					clippy::items_after_statements,
+					clippy::trivially_copy_pass_by_ref,
+					clippy::needless_borrow,
+					clippy::identity_op,
+				)]
+				fn x11_size(&self) -> usize {
+					let mut size: usize = 0;
+					// Destructure the struct's fields, if any.
+					let Self #pat = self;
 
-						// Add the size of each element.
-						#sizes
+					// Add the size of each element.
+					#sizes
 
-						// Return the cumulative size.
-						size
-					}
+					// Return the cumulative size.
+					size
 				}
-			)
-		});
+			}
+		));
 	}
 }
 
@@ -67,27 +70,30 @@ impl Request {
 			}
 		});
 
-		tokens.append_tokens({
-			quote_spanned!(trait_path.span()=>
-				#[automatically_derived]
-				impl #impl_generics #trait_path for #ident #type_generics #where_clause {
-					#[allow(clippy::items_after_statements, clippy::trivially_copy_pass_by_ref, clippy::needless_borrow, clippy::identity_op)]
-					fn x11_size(&self) -> usize {
-						// The size starts at `4` to account for the size
-						// of a request's header being 4 bytes.
-						let mut size: usize = 4;
-						// Destructure the request's fields, if any.
-						let Self #pat = self;
+		tokens.append_tokens(quote_spanned!(trait_path.span()=>
+			#[automatically_derived]
+			impl #impl_generics ::xrbk::X11Size #ident #type_generics #where_clause {
+				#[allow(
+					clippy::items_after_statements,
+					clippy::trivially_copy_pass_by_ref,
+					clippy::needless_borrow,
+					clippy::identity_op,
+				)]
+				fn x11_size(&self) -> usize {
+					// The size starts at `4` to account for the size
+					// of a request's header being 4 bytes.
+					let mut size: usize = 4;
+					// Destructure the request's fields, if any.
+					let Self #pat = self;
 
-						// Add the size of each element.
-						#sizes
+					// Add the size of each element.
+					#sizes
 
-						// Return the cumulative size.
-						size
-					}
+					// Return the cumulative size.
+					size
 				}
-			)
-		});
+			}
+		));
 	}
 }
 
@@ -110,27 +116,30 @@ impl Reply {
 			}
 		});
 
-		tokens.append_tokens({
-			quote_spanned!(trait_path.span()=>
-				#[automatically_derived]
-				impl #impl_generics #trait_path for #ident #type_generics #where_clause {
-					#[allow(clippy::items_after_statements, clippy::trivially_copy_pass_by_ref, clippy::needless_borrow, clippy::identity_op)]
-					fn x11_size(&self) -> usize {
-						// The size starts at `8` to account for the size
-						// of a reply's header being 8 bytes.
-						let mut size: usize = 8;
-						// Destructure the reply's fields, if any.
-						let Self #pat = self;
+		tokens.append_tokens(quote_spanned!(trait_path.span()=>
+			#[automatically_derived]
+			impl #impl_generics ::xrbk::X11Size #ident #type_generics #where_clause {
+				#[allow(
+					clippy::items_after_statements,
+					clippy::trivially_copy_pass_by_ref,
+					clippy::needless_borrow,
+					clippy::identity_op,
+				)]
+				fn x11_size(&self) -> usize {
+					// The size starts at `8` to account for the size
+					// of a reply's header being 8 bytes.
+					let mut size: usize = 8;
+					// Destructure the reply's fields, if any.
+					let Self #pat = self;
 
-						// Add the size of each element.
-						#sizes
+					// Add the size of each element.
+					#sizes
 
-						// Return the cumulative size.
-						size
-					}
+					// Return the cumulative size.
+					size
 				}
-			)
-		});
+			}
+		));
 	}
 }
 
@@ -159,29 +168,32 @@ impl Event {
 			}
 		});
 
-		tokens.append_tokens({
-			quote_spanned!(trait_path.span()=>
-				#[automatically_derived]
-				impl #impl_generics #trait_path for #ident #type_generics #where_clause {
-					#[allow(clippy::items_after_statements, clippy::trivially_copy_pass_by_ref, clippy::needless_borrow, clippy::identity_op)]
-					fn x11_size(&self) -> usize {
-						// The size starts at either `4` or `1`, depending
-						// on whether there is a sequence field and metabyte
-						// position, to account for the size of the event's
-						// header.
-						let mut size: usize = #size;
-						// Destructure the event's fields, if any.
-						let Self #pat = self;
+		tokens.append_tokens(quote_spanned!(trait_path.span()=>
+			#[automatically_derived]
+			impl #impl_generics ::xrbk::X11Size #ident #type_generics #where_clause {
+				#[allow(
+					clippy::items_after_statements,
+					clippy::trivially_copy_pass_by_ref,
+					clippy::needless_borrow,
+					clippy::identity_op,
+				)]
+				fn x11_size(&self) -> usize {
+					// The size starts at either `4` or `1`, depending
+					// on whether there is a sequence field and metabyte
+					// position, to account for the size of the event's
+					// header.
+					let mut size: usize = #size;
+					// Destructure the event's fields, if any.
+					let Self #pat = self;
 
-						// Add the size of each element.
-						#sizes
+					// Add the size of each element.
+					#sizes
 
-						// Return the cumulative size.
-						size
-					}
+					// Return the cumulative size.
+					size
 				}
-			)
-		});
+			}
+		));
 	}
 }
 
@@ -210,14 +222,12 @@ impl Enum {
 					}
 				});
 
-				tokens.append_tokens({
-					quote_spanned!(trait_path.span()=>
-						Self::#ident #pat => {
-							// Add the size of each element.
-							#sizes
-						},
-					)
-				});
+				tokens.append_tokens(quote_spanned!(trait_path.span()=>
+					Self::#ident #pat => {
+						// Add the size of each element.
+						#sizes
+					},
+				));
 			}
 		});
 
@@ -227,8 +237,14 @@ impl Enum {
 
 		tokens.append_tokens(quote_spanned!(trait_path.span()=>
 			#[automatically_derived]
-			impl #impl_generics #trait_path for #ident #type_generics #where_clause {
-				#[allow(clippy::items_after_statements, clippy::trivially_copy_pass_by_ref, clippy::needless_borrow, clippy::identity_op, unused_mut)]
+			impl #impl_generics ::xrbk::X11Size #ident #type_generics #where_clause {
+				#[allow(
+					clippy::items_after_statements,
+					clippy::trivially_copy_pass_by_ref,
+					clippy::needless_borrow,
+					clippy::identity_op,
+					unused_mut,
+				)]
 				fn x11_size(&self) -> usize {
 					let mut size: usize = #discrim_type::X11_SIZE;
 

--- a/xrbk_macro/src/definition/expansion/x11_size.rs
+++ b/xrbk_macro/src/definition/expansion/x11_size.rs
@@ -28,7 +28,7 @@ impl Struct {
 
 		tokens.append_tokens(quote_spanned!(trait_path.span()=>
 			#[automatically_derived]
-			impl #impl_generics ::xrbk::X11Size #ident #type_generics #where_clause {
+			impl #impl_generics ::xrbk::X11Size for #ident #type_generics #where_clause {
 				#[allow(
 					clippy::items_after_statements,
 					clippy::trivially_copy_pass_by_ref,
@@ -72,7 +72,7 @@ impl Request {
 
 		tokens.append_tokens(quote_spanned!(trait_path.span()=>
 			#[automatically_derived]
-			impl #impl_generics ::xrbk::X11Size #ident #type_generics #where_clause {
+			impl #impl_generics ::xrbk::X11Size for #ident #type_generics #where_clause {
 				#[allow(
 					clippy::items_after_statements,
 					clippy::trivially_copy_pass_by_ref,
@@ -118,7 +118,7 @@ impl Reply {
 
 		tokens.append_tokens(quote_spanned!(trait_path.span()=>
 			#[automatically_derived]
-			impl #impl_generics ::xrbk::X11Size #ident #type_generics #where_clause {
+			impl #impl_generics ::xrbk::X11Size for #ident #type_generics #where_clause {
 				#[allow(
 					clippy::items_after_statements,
 					clippy::trivially_copy_pass_by_ref,
@@ -170,7 +170,7 @@ impl Event {
 
 		tokens.append_tokens(quote_spanned!(trait_path.span()=>
 			#[automatically_derived]
-			impl #impl_generics ::xrbk::X11Size #ident #type_generics #where_clause {
+			impl #impl_generics ::xrbk::X11Size for #ident #type_generics #where_clause {
 				#[allow(
 					clippy::items_after_statements,
 					clippy::trivially_copy_pass_by_ref,
@@ -237,7 +237,7 @@ impl Enum {
 
 		tokens.append_tokens(quote_spanned!(trait_path.span()=>
 			#[automatically_derived]
-			impl #impl_generics ::xrbk::X11Size #ident #type_generics #where_clause {
+			impl #impl_generics ::xrbk::X11Size for #ident #type_generics #where_clause {
 				#[allow(
 					clippy::items_after_statements,
 					clippy::trivially_copy_pass_by_ref,


### PR DESCRIPTION
This is because previously it would use the exact same path as written in the macro syntax, requiring the written traits to be imported.  The confusing part here is that within the macro syntax, that requires the _traits_ to be imported, but using the same derive normally requires the _derive macros_ to be imported.