### PR TITLE
CI: Ignore blame revs + ignore failed push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           git pull origin ${{ github.ref }}
           git diff --quiet || echo "### Applied recommended clippy fixes." >> $GITHUB_STEP_SUMMARY
-          git diff --quiet || (git commit -am "[CI${{ github.run_number}}] applied recommended clippy fixes" && echo "$(git log --format='%H' -n 1)" >> $GITHUB_STEP_SUMMARY && echo "$(git log --format='%H' -n 1 >> .git-blame-ignore-revs)
+          git diff --quiet || (git commit -am "[CI${{ github.run_number}}] applied recommended clippy fixes" && echo "$(git log --format='%H' -n 1)" >> $GITHUB_STEP_SUMMARY && echo "$(git log --format='%H' -n 1" >> .git-blame-ignore-revs)
 
       # Automatically format the code with `rustfmt`.
       - name: Format code with `rustfmt`
@@ -80,7 +80,7 @@ jobs:
         run: |
           git pull origin ${{ github.ref }}
           git diff --quiet || echo "### Formatted code with rustfmt." >> $GITHUB_STEP_SUMMARY
-          git diff --quiet || (git commit -am "[CI${{ github.run_number}}] formatted code with rustfmt" && echo "$(git log --format='%H' -n 1)" >> $GITHUB_STEP_SUMMARY && echo "$(git log --format='%H' -n 1 >> .git-blame-ignore-revs)
+          git diff --quiet || (git commit -am "[CI${{ github.run_number}}] formatted code with rustfmt" && echo "$(git log --format='%H' -n 1)" >> $GITHUB_STEP_SUMMARY && echo "$(git log --format='%H' -n 1" >> .git-blame-ignore-revs)
 
       # This sets the `commit-id` to the latest commit. If there were changes
       # made, that means it will be the commit for those changes, otherwise it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           git pull origin ${{ github.ref }}
           git diff --quiet || echo "### Applied recommended clippy fixes." >> $GITHUB_STEP_SUMMARY
-          git diff --quiet || (git commit -am "[CI${{ github.run_number}}] applied recommended clippy fixes" && echo "$(git log --format='%H' -n 1)" >> $GITHUB_STEP_SUMMARY && echo "$(git log --format='%H' -n 1" >> .git-blame-ignore-revs)
+          git diff --quiet || (git commit -am "[CI${{ github.run_number}}] applied recommended clippy fixes" && echo "$(git log --format='%H' -n 1)" >> $GITHUB_STEP_SUMMARY && echo "$(git log --format='%H' -n 1)" >> .git-blame-ignore-revs)
 
       # Automatically format the code with `rustfmt`.
       - name: Format code with `rustfmt`
@@ -80,7 +80,7 @@ jobs:
         run: |
           git pull origin ${{ github.ref }}
           git diff --quiet || echo "### Formatted code with rustfmt." >> $GITHUB_STEP_SUMMARY
-          git diff --quiet || (git commit -am "[CI${{ github.run_number}}] formatted code with rustfmt" && echo "$(git log --format='%H' -n 1)" >> $GITHUB_STEP_SUMMARY && echo "$(git log --format='%H' -n 1" >> .git-blame-ignore-revs)
+          git diff --quiet || (git commit -am "[CI${{ github.run_number}}] formatted code with rustfmt" && echo "$(git log --format='%H' -n 1)" >> $GITHUB_STEP_SUMMARY && echo "$(git log --format='%H' -n 1)" >> .git-blame-ignore-revs)
 
       # This sets the `commit-id` to the latest commit. If there were changes
       # made, that means it will be the commit for those changes, otherwise it

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           git pull origin ${{ github.ref }}
           git diff --quiet || echo "### Applied recommended clippy fixes." >> $GITHUB_STEP_SUMMARY
-          git diff --quiet || (git commit -am "[CI${{ github.run_number}}] applied recommended clippy fixes" && echo "$(git log --format='%H' -n 1)" >> $GITHUB_STEP_SUMMARY)
+          git diff --quiet || (git commit -am "[CI${{ github.run_number}}] applied recommended clippy fixes" && echo "$(git log --format='%H' -n 1)" >> $GITHUB_STEP_SUMMARY && echo "$(git log --format='%H' -n 1 >> .git-blame-ignore-revs)
 
       # Automatically format the code with `rustfmt`.
       - name: Format code with `rustfmt`
@@ -80,7 +80,7 @@ jobs:
         run: |
           git pull origin ${{ github.ref }}
           git diff --quiet || echo "### Formatted code with rustfmt." >> $GITHUB_STEP_SUMMARY
-          git diff --quiet || (git commit -am "[CI${{ github.run_number}}] formatted code with rustfmt" && echo "$(git log --format='%H' -n 1)" >> $GITHUB_STEP_SUMMARY)
+          git diff --quiet || (git commit -am "[CI${{ github.run_number}}] formatted code with rustfmt" && echo "$(git log --format='%H' -n 1)" >> $GITHUB_STEP_SUMMARY && echo "$(git log --format='%H' -n 1 >> .git-blame-ignore-revs)
 
       # This sets the `commit-id` to the latest commit. If there were changes
       # made, that means it will be the commit for those changes, otherwise it
@@ -90,7 +90,8 @@ jobs:
         run: echo "COMMIT_ID=$(git log --format='%H' -n 1)" >> $GITHUB_OUTPUT
 
       - name: Push changes
-        run: git push origin HEAD:${{ github.ref }}
+        run: |
+          git push origin HEAD:${{ github.ref }} || :
 
   # Runs unit tests.
   run-tests:


### PR DESCRIPTION
This adds any committed commits to the `.git-ignore-blame-revs` file so that auto-formatting changes don't show in git blame, and also doesn't cause the `fix-n-format` job to fail if a `git push` failed.