### PR TITLE
Added units to represent things like pixels or millimeters

### DIFF
--- a/src/common.rs
+++ b/src/common.rs
@@ -2,11 +2,13 @@
 // License, v. 2.0. If a copy of the MPL was not distributed with this
 // file, You can obtain one at https://mozilla.org/MPL/2.0/.
 
-extern crate self as xrb;
+use crate::unit::Px;
+use xrbk::{Buf, ConstantX11Size, ReadError, ReadResult, ReadableWithContext, Wrap};
 
 use derive_more::{From, Into};
-use xrbk::{Buf, ConstantX11Size, ReadError, ReadResult, ReadableWithContext, Wrap};
+
 use xrbk_macro::{derive_xrb, new, unwrap, ConstantX11Size, Readable, Wrap, Writable, X11Size};
+extern crate self as xrb;
 
 pub mod atom;
 pub mod set;
@@ -349,44 +351,44 @@ impl ReadableWithContext for String16 {
 )]
 pub struct Point {
 	#[allow(missing_docs)]
-	pub x: i16,
+	pub x: Px<i16>,
 	#[allow(missing_docs)]
-	pub y: i16,
+	pub y: Px<i16>,
 }
 
 /// A rectangle with coordinates and dimensions.
 #[derive(Clone, Eq, PartialEq, Hash, Debug, new, X11Size, ConstantX11Size, Readable, Writable)]
 pub struct Rectangle {
 	/// The x-coordinate of the upper left corner of the `Rectangle`.
-	pub x: i16,
+	pub x: Px<i16>,
 	/// The y-coordinate of the upper left corner of the `Rectangle`.
-	pub y: i16,
+	pub y: Px<i16>,
 	/// The width of the `Rectangle`.
-	pub width: u16,
+	pub width: Px<u16>,
 	/// The height of the `Rectangle`.
-	pub height: u16,
+	pub height: Px<u16>,
 }
 
 /// Same as a [`Rectangle`], but with unsigned coordinates.
 #[derive(Clone, Eq, PartialEq, Hash, Debug, new, X11Size, ConstantX11Size, Readable, Writable)]
 pub struct Region {
 	/// The x-coordinate of the upper left corner of the `Region`.
-	pub x: u16,
+	pub x: Px<u16>,
 	/// The y-coordinate of the upper left corner of the `Region`.
-	pub y: u16,
+	pub y: Px<u16>,
 
 	/// The width of the `Region`.
-	pub width: u16,
+	pub width: Px<u16>,
 	/// The height of the `Region`.
-	pub height: u16,
+	pub height: Px<u16>,
 }
 
 #[derive(Clone, Eq, PartialEq, Hash, Debug, new, X11Size, ConstantX11Size, Readable, Writable)]
 pub struct Arc {
-	pub x: i16,
-	pub y: i16,
-	pub width: u16,
-	pub height: u16,
+	pub x: Px<i16>,
+	pub y: Px<i16>,
+	pub width: Px<u16>,
+	pub height: Px<u16>,
 
 	/// Specifies the start of the `Arc`.
 	///

--- a/src/common/atom.rs
+++ b/src/common/atom.rs
@@ -26,7 +26,7 @@ use xrbk_macro::{ConstantX11Size, Readable, Wrap, Writable, X11Size};
 	Writable,
 	Wrap,
 )]
-pub struct Atom(pub(crate) u32);
+pub struct Atom(u32);
 
 impl Atom {
 	/// Creates a new `Atom`, wrapping the given `id`.

--- a/src/common/res_id.rs
+++ b/src/common/res_id.rs
@@ -35,7 +35,7 @@ use xrbk_macro::{new, unwrap, ConstantX11Size, Readable, Wrap, Writable, X11Size
 	Writable,
 	Wrap,
 )]
-pub struct Drawable(pub(crate) u32);
+pub struct Drawable(u32);
 
 impl From<Window> for Drawable {
 	fn from(window: Window) -> Self {
@@ -84,7 +84,7 @@ impl From<Pixmap> for Drawable {
 	Writable,
 	Wrap,
 )]
-pub struct Window(pub(crate) u32);
+pub struct Window(u32);
 
 impl From<Drawable> for Window {
 	fn from(drawable: Drawable) -> Self {
@@ -122,7 +122,7 @@ impl From<Drawable> for Window {
 	Writable,
 	Wrap,
 )]
-pub struct Pixmap(pub(crate) u32);
+pub struct Pixmap(u32);
 
 impl From<Drawable> for Pixmap {
 	fn from(drawable: Drawable) -> Self {
@@ -160,7 +160,7 @@ impl From<Drawable> for Pixmap {
 	Writable,
 	Wrap,
 )]
-pub struct CursorAppearance(pub(crate) u32);
+pub struct CursorAppearance(u32);
 
 /// A resource ID referring to either a [`Font`] or a [`GraphicsContext`].
 #[derive(
@@ -182,7 +182,7 @@ pub struct CursorAppearance(pub(crate) u32);
 	Writable,
 	Wrap,
 )]
-pub struct Fontable(pub(crate) u32);
+pub struct Fontable(u32);
 
 impl From<Font> for Fontable {
 	fn from(font: Font) -> Self {
@@ -227,7 +227,7 @@ impl From<GraphicsContext> for Fontable {
 	Writable,
 	Wrap,
 )]
-pub struct Font(pub(crate) u32);
+pub struct Font(u32);
 
 impl From<Fontable> for Font {
 	fn from(fontable: Fontable) -> Self {
@@ -271,7 +271,7 @@ impl From<Fontable> for Font {
 	Writable,
 	Wrap,
 )]
-pub struct GraphicsContext(pub(crate) u32);
+pub struct GraphicsContext(u32);
 
 impl From<Fontable> for GraphicsContext {
 	fn from(fontable: Fontable) -> Self {
@@ -309,4 +309,4 @@ impl From<Fontable> for GraphicsContext {
 	Writable,
 	Wrap,
 )]
-pub struct Colormap(pub(crate) u32);
+pub struct Colormap(u32);

--- a/src/common/set.rs
+++ b/src/common/set.rs
@@ -19,6 +19,7 @@
 //!   - [`WindowConfigBuilder`]
 //!   - [`WindowConfigMask`]
 
+use crate::unit::Px;
 use xrbk::{
 	Buf,
 	BufMut,
@@ -56,6 +57,63 @@ pub(self) fn read_set_value<T: Readable>(
 		None
 	})
 }
+
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+pub(self) struct __Px<Num>(Px<Num>);
+
+impl<Num> ConstantX11Size for __Px<Num> {
+	const X11_SIZE: usize = 4;
+}
+
+impl<Num> X11Size for __Px<Num> {
+	fn x11_size(&self) -> usize {
+		Self::X11_SIZE
+	}
+}
+
+/// Implements the internal `__Px` representation for the given numerical
+/// primitives.
+macro_rules! impl_px {
+	(
+		$get:ident, $put:ty => {
+			$(
+				$type:tt
+			),*$(,)?
+		}
+	) => {
+		$(
+			impl Readable for __Px<$type> {
+				fn read_from(buf: &mut impl Buf) -> ReadResult<Self> {
+					Ok(Self(Px(match <$type>::try_from(buf.$get()) {
+						Ok($type) => $type,
+
+						Err(err) => return Err(ReadError::FailedConversion(Box::new(err))),
+					})))
+				}
+			}
+
+			impl Writable for __Px<$type> {
+				fn write_to(&self, buf: &mut impl BufMut) -> WriteResult {
+					let Self(Px($type)) = self;
+
+					<$put>::from(*$type).write_to(buf)?;
+
+					Ok(())
+				}
+			}
+		)*
+	};
+}
+
+impl_px!(get_u32, u32 => {
+	u8,
+	u16,
+});
+
+impl_px!(get_i32, i32 => {
+	i8,
+	i16,
+});
 
 /// Wraps a `u8` value, but writes it as four bytes in the X11 format.
 ///

--- a/src/common/set/graphics_options.rs
+++ b/src/common/set/graphics_options.rs
@@ -5,8 +5,8 @@
 use xrbk_macro::{ConstantX11Size, Readable, Writable, X11Size};
 
 use crate::{
-	common::set::__bool,
-	set::{__i16, __u16, __u8},
+	set::{__Px, __bool, __u8},
+	unit::Px,
 	visual::Color,
 	Font,
 	Pixmap,
@@ -353,8 +353,8 @@ pub struct GraphicsOptions {
 	tile: Option<Pixmap>,
 	stipple: Option<Pixmap>,
 
-	tile_stipple_x: Option<__i16>,
-	tile_stipple_y: Option<__i16>,
+	tile_stipple_x: Option<__Px<i16>>,
+	tile_stipple_y: Option<__Px<i16>>,
 
 	font: Option<Font>,
 
@@ -362,11 +362,11 @@ pub struct GraphicsOptions {
 
 	graphics_exposures: Option<__bool>,
 
-	clip_x: Option<__i16>,
-	clip_y: Option<__i16>,
+	clip_x: Option<__Px<i16>>,
+	clip_y: Option<__Px<i16>>,
 	clip_mask: Option<ClipMask>,
 
-	dash_offset: Option<__u16>,
+	dash_offset: Option<__Px<u16>>,
 	dashes: Option<__u8>,
 
 	arc_mode: Option<__ArcMode>,
@@ -413,8 +413,8 @@ pub struct GraphicsOptionsBuilder {
 	tile: Option<Pixmap>,
 	stipple: Option<Pixmap>,
 
-	tile_stipple_x: Option<i16>,
-	tile_stipple_y: Option<i16>,
+	tile_stipple_x: Option<Px<i16>>,
+	tile_stipple_y: Option<Px<i16>>,
 
 	font: Option<Font>,
 
@@ -422,11 +422,11 @@ pub struct GraphicsOptionsBuilder {
 
 	graphics_exposures: Option<bool>,
 
-	clip_x: Option<i16>,
-	clip_y: Option<i16>,
+	clip_x: Option<Px<i16>>,
+	clip_y: Option<Px<i16>>,
 	clip_mask: Option<ClipMask>,
 
-	dash_offset: Option<u16>,
+	dash_offset: Option<Px<u16>>,
 	dashes: Option<u8>,
 
 	arc_mode: Option<ArcMode>,
@@ -514,8 +514,8 @@ impl GraphicsOptionsBuilder {
 			tile: self.tile,
 			stipple: self.stipple,
 
-			tile_stipple_x: self.tile_stipple_x.map(__i16),
-			tile_stipple_y: self.tile_stipple_y.map(__i16),
+			tile_stipple_x: self.tile_stipple_x.map(__Px),
+			tile_stipple_y: self.tile_stipple_y.map(__Px),
 
 			font: self.font,
 
@@ -523,11 +523,11 @@ impl GraphicsOptionsBuilder {
 
 			graphics_exposures: self.graphics_exposures.map(__bool),
 
-			clip_x: self.clip_x.map(__i16),
-			clip_y: self.clip_y.map(__i16),
+			clip_x: self.clip_x.map(__Px),
+			clip_y: self.clip_y.map(__Px),
 			clip_mask: self.clip_mask,
 
-			dash_offset: self.dash_offset.map(__u16),
+			dash_offset: self.dash_offset.map(__Px),
 			dashes: self.dashes.map(__u8),
 
 			arc_mode: self.arc_mode.map(__ArcMode),
@@ -728,7 +728,7 @@ impl GraphicsOptionsBuilder {
 	/// [x]: GraphicsOptions::tile_stipple_x
 	/// [tile]: GraphicsOptions::tile
 	/// [stipple]: GraphicsOptions::stipple
-	pub fn tile_stipple_x(&mut self, tile_stipple_x: i16) -> &mut Self {
+	pub fn tile_stipple_x(&mut self, tile_stipple_x: Px<i16>) -> &mut Self {
 		if self.tile_stipple_x.is_none() {
 			self.x11_size += 4;
 		}
@@ -746,7 +746,7 @@ impl GraphicsOptionsBuilder {
 	/// [y]: GraphicsOptions::tile_stipple_y
 	/// [tile]: GraphicsOptions::tile
 	/// [stipple]: GraphicsOptions::stipple
-	pub fn tile_stipple_y(&mut self, tile_stipple_y: i16) -> &mut Self {
+	pub fn tile_stipple_y(&mut self, tile_stipple_y: Px<i16>) -> &mut Self {
 		if self.tile_stipple_y.is_none() {
 			self.x11_size += 4;
 		}
@@ -813,7 +813,7 @@ impl GraphicsOptionsBuilder {
 	/// See [`GraphicsOptions::clip_x`] for more information.
 	///
 	/// [x]: GraphicsOptions::clip_x
-	pub fn clip_x(&mut self, clip_x: i16) -> &mut Self {
+	pub fn clip_x(&mut self, clip_x: Px<i16>) -> &mut Self {
 		if self.clip_x.is_none() {
 			self.x11_size += 4;
 		}
@@ -829,7 +829,7 @@ impl GraphicsOptionsBuilder {
 	/// See [`GraphicsOptions::clip_y`] for more information.
 	///
 	/// [y]: GraphicsOptions::clip_y
-	pub fn clip_y(&mut self, clip_y: i16) -> &mut Self {
+	pub fn clip_y(&mut self, clip_y: Px<i16>) -> &mut Self {
 		if self.clip_y.is_none() {
 			self.x11_size += 4;
 		}
@@ -860,7 +860,7 @@ impl GraphicsOptionsBuilder {
 	/// See [`GraphicsOptions::dash_offset`] for more information.
 	///
 	/// [`dash_offset`]: GraphicsOptions::dash_offset
-	pub fn dash_offset(&mut self, dash_offset: u16) -> &mut Self {
+	pub fn dash_offset(&mut self, dash_offset: Px<u16>) -> &mut Self {
 		if self.dash_offset.is_none() {
 			self.x11_size += 4;
 		}
@@ -922,30 +922,18 @@ impl GraphicsOptions {
 	///
 	/// [`function`]: GraphicsOptions::function
 	#[must_use]
-	#[allow(
-		clippy::missing_const_for_fn,
-		reason = "const omitted for API uniformity with the other methods"
-	)]
-	pub fn plane_mask(&self) -> Option<&u32> {
+	pub const fn plane_mask(&self) -> Option<&u32> {
 		self.plane_mask.as_ref()
 	}
 
 	/// The foreground color used in graphics operations.
 	#[must_use]
-	#[allow(
-		clippy::missing_const_for_fn,
-		reason = "const omitted for API uniformity with the other methods"
-	)]
-	pub fn foreground_color(&self) -> Option<&Color> {
+	pub const fn foreground_color(&self) -> Option<&Color> {
 		self.foreground_color.as_ref()
 	}
 	/// The background color used in graphics operations.
 	#[must_use]
-	#[allow(
-		clippy::missing_const_for_fn,
-		reason = "const omitted for API uniformity with the other methods"
-	)]
-	pub fn background_color(&self) -> Option<&Color> {
+	pub const fn background_color(&self) -> Option<&Color> {
 		self.background_color.as_ref()
 	}
 
@@ -1012,22 +1000,14 @@ impl GraphicsOptions {
 	///
 	/// [pixmap]: Pixmap
 	#[must_use]
-	#[allow(
-		clippy::missing_const_for_fn,
-		reason = "const omitted for API uniformity with the other methods"
-	)]
-	pub fn tile(&self) -> Option<&Pixmap> {
+	pub const fn tile(&self) -> Option<&Pixmap> {
 		self.tile.as_ref()
 	}
 	/// The [pixmap] which is stippled in graphics operations.
 	///
 	/// [pixmap]: Pixmap
 	#[must_use]
-	#[allow(
-		clippy::missing_const_for_fn,
-		reason = "const omitted for API uniformity with the other methods"
-	)]
-	pub fn stipple(&self) -> Option<&Pixmap> {
+	pub const fn stipple(&self) -> Option<&Pixmap> {
 		self.stipple.as_ref()
 	}
 
@@ -1039,8 +1019,8 @@ impl GraphicsOptions {
 	///
 	/// [drawable]: crate::Drawable
 	#[must_use]
-	pub fn tile_stipple_x(&self) -> Option<&i16> {
-		self.tile_stipple_x.as_ref().map(|__i16(x)| x)
+	pub fn tile_stipple_x(&self) -> Option<&Px<i16>> {
+		self.tile_stipple_x.as_ref().map(|__Px(x)| x)
 	}
 	/// The y coordinate of the top-left corner of the [tile] or [stipple]
 	/// [`Pixmap`], relative to the [drawable]'s top-left corner.
@@ -1050,19 +1030,15 @@ impl GraphicsOptions {
 	///
 	/// [drawable]: crate::Drawable
 	#[must_use]
-	pub fn tile_stipple_y(&self) -> Option<&i16> {
-		self.tile_stipple_y.as_ref().map(|__i16(y)| y)
+	pub fn tile_stipple_y(&self) -> Option<&Px<i16>> {
+		self.tile_stipple_y.as_ref().map(|__Px(y)| y)
 	}
 
 	/// The [font] used for text.
 	///
 	/// [font]: Font
 	#[must_use]
-	#[allow(
-		clippy::missing_const_for_fn,
-		reason = "const omitted for API uniformity with the other methods"
-	)]
-	pub fn font(&self) -> Option<&Font> {
+	pub const fn font(&self) -> Option<&Font> {
 		self.font.as_ref()
 	}
 
@@ -1093,8 +1069,8 @@ impl GraphicsOptions {
 	/// [`clip_mask`]: GraphicsOptions::clip_mask
 	/// [drawable]: crate::Drawable
 	#[must_use]
-	pub fn clip_x(&self) -> Option<&i16> {
-		self.clip_x.as_ref().map(|__i16(x)| x)
+	pub fn clip_x(&self) -> Option<&Px<i16>> {
+		self.clip_x.as_ref().map(|__Px(x)| x)
 	}
 	/// The y coordinate of the top-left corner of the [`clip_mask`], relative
 	/// to the [drawable]'s top-left corner.
@@ -1102,8 +1078,8 @@ impl GraphicsOptions {
 	/// [`clip_mask`]: GraphicsOptions::clip_mask
 	/// [drawable]: crate::Drawable
 	#[must_use]
-	pub fn clip_y(&self) -> Option<&i16> {
-		self.clip_y.as_ref().map(|__i16(y)| y)
+	pub fn clip_y(&self) -> Option<&Px<i16>> {
+		self.clip_y.as_ref().map(|__Px(y)| y)
 	}
 	/// A mask applied to the [drawable] when using graphics operations.
 	///
@@ -1111,21 +1087,17 @@ impl GraphicsOptions {
 	///
 	/// [drawable]: crate::Drawable
 	#[must_use]
-	#[allow(
-		clippy::missing_const_for_fn,
-		reason = "const omitted for API uniformity with the other methods"
-	)]
-	pub fn clip_mask(&self) -> Option<&ClipMask> {
+	pub const fn clip_mask(&self) -> Option<&ClipMask> {
 		self.clip_mask.as_ref()
 	}
 
 	/// The offset from the endpoints or joinpoints of a line from which dashes
 	/// are drawn.
 	#[must_use]
-	pub fn dash_offset(&self) -> Option<&u16> {
+	pub fn dash_offset(&self) -> Option<&Px<u16>> {
 		self.dash_offset
 			.as_ref()
-			.map(|__u16(dash_offset)| dash_offset)
+			.map(|__Px(dash_offset)| dash_offset)
 	}
 	/// Specifies the length of dashes used in [`LineStyle::DoubleDash`] and
 	/// [`LineStyle::OnOffDash`] lines.
@@ -1360,7 +1332,7 @@ impl X11Size for GraphicsOptions {
 }
 
 impl Readable for GraphicsOptions {
-	#[allow(clippy::similar_names, clippy::too_many_lines)]
+	#[allow(clippy::too_many_lines)]
 	fn read_from(buf: &mut impl Buf) -> ReadResult<Self>
 	where
 		Self: Sized,
@@ -1716,10 +1688,6 @@ impl X11Size for __LineWidth {
 }
 
 impl Readable for __LineWidth {
-	#[allow(
-		clippy::cast_possible_truncation,
-		reason = "truncation is intended behavior if the width is too large for a u16 value"
-	)]
 	fn read_from(buf: &mut impl Buf) -> ReadResult<Self>
 	where
 		Self: Sized,

--- a/src/common/set/keyboard_options.rs
+++ b/src/common/set/keyboard_options.rs
@@ -869,9 +869,10 @@ impl Readable for __PercentOrDefault {
 			reset if reset == -1 => PercentOrDefault::Default,
 
 			value => match u8::try_from(value) {
-				Ok(value) if let Ok(percent) = Percentage::new(value) => {
-					PercentOrDefault::Percent(percent)
-				},
+				Ok(value) if (0..=100).contains(&value) => PercentOrDefault::Percent(unsafe {
+					// We can use this because we have ensured its bounds are respected.
+					Percentage::new_unchecked(value)
+				}),
 
 				_ => {
 					return Err(ReadError::Other(Box::new(ValueOutOfBounds {

--- a/src/common/set/window_configs.rs
+++ b/src/common/set/window_configs.rs
@@ -4,7 +4,7 @@
 
 use crate::{StackMode, Window};
 
-use crate::set::{__i16, __u16};
+use crate::{set::__Px, unit::Px};
 use bitflags::bitflags;
 use xrbk::{
 	Buf,
@@ -40,12 +40,12 @@ pub struct WindowConfig {
 
 	mask: WindowConfigMask,
 
-	x: Option<__i16>,
-	y: Option<__i16>,
-	width: Option<__u16>,
-	height: Option<__u16>,
+	x: Option<__Px<i16>>,
+	y: Option<__Px<i16>>,
+	width: Option<__Px<u16>>,
+	height: Option<__Px<u16>>,
 
-	border_width: Option<__u16>,
+	border_width: Option<__Px<u16>>,
 
 	sibling: Option<Window>,
 
@@ -75,12 +75,12 @@ pub struct WindowConfigBuilder {
 
 	mask: WindowConfigMask,
 
-	x: Option<i16>,
-	y: Option<i16>,
-	width: Option<u16>,
-	height: Option<u16>,
+	x: Option<Px<i16>>,
+	y: Option<Px<i16>>,
+	width: Option<Px<u16>>,
+	height: Option<Px<u16>>,
 
-	border_width: Option<u16>,
+	border_width: Option<Px<u16>>,
 
 	sibling: Option<Window>,
 
@@ -126,12 +126,12 @@ impl WindowConfigBuilder {
 
 			mask: self.mask,
 
-			x: self.x.map(__i16),
-			y: self.y.map(__i16),
-			width: self.width.map(__u16),
-			height: self.height.map(__u16),
+			x: self.x.map(__Px),
+			y: self.y.map(__Px),
+			width: self.width.map(__Px),
+			height: self.height.map(__Px),
 
-			border_width: self.border_width.map(__u16),
+			border_width: self.border_width.map(__Px),
 
 			sibling: self.sibling,
 
@@ -147,7 +147,7 @@ impl WindowConfigBuilder {
 	///
 	/// [x coordinate]: WindowConfig::x
 	/// [window]: Window
-	pub fn x(&mut self, x: i16) -> &mut Self {
+	pub fn x(&mut self, x: Px<i16>) -> &mut Self {
 		if self.x.is_none() {
 			self.x11_size += 4;
 		}
@@ -163,7 +163,7 @@ impl WindowConfigBuilder {
 	///
 	/// [y coordinate]: WindowConfig::y
 	/// [window]: Window
-	pub fn y(&mut self, y: i16) -> &mut Self {
+	pub fn y(&mut self, y: Px<i16>) -> &mut Self {
 		if self.y.is_none() {
 			self.x11_size += 4;
 		}
@@ -179,7 +179,7 @@ impl WindowConfigBuilder {
 	///
 	/// [width]: WindowConfig::width
 	/// [window]: Window
-	pub fn width(&mut self, width: u16) -> &mut Self {
+	pub fn width(&mut self, width: Px<u16>) -> &mut Self {
 		if self.width.is_none() {
 			self.x11_size += 4;
 		}
@@ -195,7 +195,7 @@ impl WindowConfigBuilder {
 	///
 	/// [height]: WindowConfig::height
 	/// [window]: Window
-	pub fn height(&mut self, height: u16) -> &mut Self {
+	pub fn height(&mut self, height: Px<u16>) -> &mut Self {
 		if self.height.is_none() {
 			self.x11_size += 4;
 		}
@@ -211,7 +211,7 @@ impl WindowConfigBuilder {
 	/// See [`WindowConfig::border_width`] for more information.
 	///
 	/// [window]: Window
-	pub fn border_width(&mut self, border_width: u16) -> &mut Self {
+	pub fn border_width(&mut self, border_width: Px<u16>) -> &mut Self {
 		if self.border_width.is_none() {
 			self.x11_size += 4;
 		}
@@ -266,39 +266,39 @@ impl WindowConfig {
 	///
 	/// [window]: Window
 	#[must_use]
-	pub fn x(&self) -> Option<&i16> {
-		self.x.as_ref().map(|__i16(x)| x)
+	pub fn x(&self) -> Option<&Px<i16>> {
+		self.x.as_ref().map(|__Px(x)| x)
 	}
 	/// The y coordinate of the [window]'s top-left corner is configured.
 	///
 	/// [window]: Window
 	#[must_use]
-	pub fn y(&self) -> Option<&i16> {
-		self.y.as_ref().map(|__i16(y)| y)
+	pub fn y(&self) -> Option<&Px<i16>> {
+		self.y.as_ref().map(|__Px(y)| y)
 	}
 	/// The width of the [window] is configured.
 	///
 	/// [window]: Window
 	#[must_use]
-	pub fn width(&self) -> Option<&u16> {
-		self.width.as_ref().map(|__u16(width)| width)
+	pub fn width(&self) -> Option<&Px<u16>> {
+		self.width.as_ref().map(|__Px(width)| width)
 	}
 	/// The height of the [window] is configured.
 	///
 	/// [window]: Window
 	#[must_use]
-	pub fn height(&self) -> Option<&u16> {
-		self.height.as_ref().map(|__u16(height)| height)
+	pub fn height(&self) -> Option<&Px<u16>> {
+		self.height.as_ref().map(|__Px(height)| height)
 	}
 
 	/// The width of the [window]'s border is configured.
 	///
 	/// [window]: Window
 	#[must_use]
-	pub fn border_width(&self) -> Option<&u16> {
+	pub fn border_width(&self) -> Option<&Px<u16>> {
 		self.border_width
 			.as_ref()
-			.map(|__u16(border_width)| border_width)
+			.map(|__Px(border_width)| border_width)
 	}
 
 	/// The sibling which the [`stack_mode`] applies to is configured.

--- a/src/common/visual.rs
+++ b/src/common/visual.rs
@@ -7,7 +7,13 @@
 	reason = "It makes sense for `Screen` to have many arguments because it has many fields."
 )]
 
-use crate::{Colormap, EventMask, MaintainContents, Window};
+use crate::{
+	unit::{Mm, Px},
+	Colormap,
+	EventMask,
+	MaintainContents,
+	Window,
+};
 use derive_more::{From, Into};
 use xrbk_macro::{derive_xrb, new, unwrap, ConstantX11Size, Readable, Wrap, Writable, X11Size};
 
@@ -297,7 +303,7 @@ impl From<RgbColor> for (u32, u32, u32) {
 	Writable,
 	Wrap,
 )]
-pub struct VisualId(pub(crate) u32);
+pub struct VisualId(u32);
 
 derive_xrb! {
 	#[derive(
@@ -321,47 +327,28 @@ derive_xrb! {
 	}
 }
 
-#[derive(
-	Copy,
-	Clone,
-	Eq,
-	PartialEq,
-	Hash,
-	Debug,
-	From,
-	Into,
-	// `new` and `unwrap` const fns
-	new,
-	unwrap,
-	// XRBK traits
-	X11Size,
-	Readable,
-	Writable,
-)]
-pub struct Millimeters(u16);
-
 derive_xrb! {
 	#[derive(Clone, Eq, PartialEq, Hash, Debug, new, X11Size, Readable, Writable)]
 	pub struct Screen {
 		pub root: Window,
 		pub default_colormap: Colormap,
 
-		pub white_pixel: u32,
-		pub black_pixel: u32,
+		pub white: Color,
+		pub black: Color,
 
 		pub current_input_masks: EventMask,
 
-		pub width_px: u16,
-		pub height_px: u16,
-		pub width_mm: Millimeters,
-		pub height_mm: Millimeters,
+		pub width_px: Px<u16>,
+		pub height_px: Px<u16>,
+		pub width_mm: Mm<u16>,
+		pub height_mm: Mm<u16>,
 
 		pub min_installed_maps: u16,
 		pub max_installed_maps: u16,
 
 		pub root_visual: VisualId,
-		pub backing_stores: MaintainContents,
-		pub save_unders: bool,
+		pub maintain_contents_mode: MaintainContents,
+		pub maintain_windows_under: bool,
 		pub root_depth: u8,
 
 		#[allow(clippy::cast_possible_truncation)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,9 @@
 // This is so we can provide a reason when we ignore a particular lint with
 // `allow`.
 #![feature(lint_reasons)]
+// // Used for convenience. Will remove if XRB is reaching stability and this is
+// // still unstable.
+// #![feature(if_let_guard)]
 #![cfg_attr(feature = "try", feature(try_trait_v2))]
 // Deny these lints.
 #![deny(clippy::correctness)]
@@ -20,6 +23,10 @@
 #![deny(clippy::perf)]
 #![deny(clippy::style)]
 #![deny(clippy::suspicious)]
+// For functions which are declared unsafe because they require a particular contract to be checked
+// by the programmer, but not because they contain unsafe code, shouldn't be allowed to have unsafe
+// code. If unsafe code is desired, an unsafe block can be used.
+#![deny(unsafe_op_in_unsafe_fn)]
 // Warn for these lints.
 #![warn(clippy::use_self)]
 #![warn(clippy::pedantic)]
@@ -74,6 +81,7 @@ pub const PROTOCOL_MINOR_VERSION: u16 = 0;
 pub(crate) mod common;
 pub mod connection;
 pub mod message;
+pub mod unit;
 pub mod x11;
 
 pub use common::*;

--- a/src/message.rs
+++ b/src/message.rs
@@ -102,7 +102,7 @@ pub trait Request: X11Size + Writable {
 	///
 	/// ```
 	/// use xrbk_macro::derive_xrb;
-	/// use xrb::{ColorChannelMask, Colormap, String8};
+	/// use xrb::{ColorChannelMask, Colormap, visual::Color, String8};
 	///
 	/// derive_xrb! {
 	///     #[derive(Debug, Hash, PartialEq, Eq, Readable, Writable, X11Size)]
@@ -111,7 +111,7 @@ pub trait Request: X11Size + Writable {
 	///         pub color_channel_mask: ColorChannelMask,
 	///
 	///         pub colormap: Colormap,
-	///         pub pixel: u32,
+	///         pub color: Color,
 	///
 	///         #[allow(clippy::cast_possible_truncation)]
 	///         let name_len: u16 = name => name.len() as u16,
@@ -262,7 +262,7 @@ pub trait Reply: X11Size + Readable {
 	///
 	/// ```
 	/// use xrbk_macro::derive_xrb;
-	/// use xrb::{atom::Atom, message::Reply, Rectangle, Window};
+	/// use xrb::{Atom, message::Reply, Rectangle, unit::Px, Window};
 	/// # use xrb::message::Request;
 	///
 	/// derive_xrb! {
@@ -282,7 +282,7 @@ pub trait Reply: X11Size + Readable {
 	///
 	///         pub root: Window, // 4 bytes
 	///         pub geometry: Rectangle, // 8 bytes
-	///         pub border_width: u16, // 2 bytes
+	///         pub border_width: Px<u16>, // 2 bytes
 	///         // Total number of bytes by now is 22; since this is less than
 	///         // the minimum length of a Reply (32 bytes), it adds 10 unused
 	///         // bytes.

--- a/src/unit.rs
+++ b/src/unit.rs
@@ -1,0 +1,169 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Types representing units like millimeters or hertz.
+
+use std::fmt::{Display, Formatter};
+use thiserror::Error;
+use xrbk::{Buf, BufMut, ConstantX11Size, ReadResult, Readable, Writable, WriteResult, X11Size};
+
+/// An error generated when a value is outside of the required bounds.
+#[derive(Clone, Debug, Hash, PartialEq, Eq, Error)]
+#[error("expected a value satisfying {} <= value <= {}, found {}", self.min, self.max, self.found)]
+pub struct ValueOutOfBounds<Num: Display> {
+	/// The minimum allowed value.
+	pub min: Num,
+	/// The maximum allowed value.
+	pub max: Num,
+
+	/// The value which did not satisfy the bounds.
+	pub found: Num,
+}
+
+macro_rules! impl_xrbk_traits {
+	($type:ident $(<$generic:ident>)?($inner:ident)) => {
+		impl$(<$generic>)? ConstantX11Size for $type$(<$generic>)?
+		$(where
+			$generic: ConstantX11Size,)?
+		{
+			const X11_SIZE: usize = <$inner>::X11_SIZE;
+		}
+
+		impl$(<$generic>)? X11Size for $type$(<$generic>)?
+		$(where
+			$generic: X11Size,)?
+		{
+			fn x11_size(&self) -> usize {
+				<$inner>::x11_size(&self.0)
+			}
+		}
+
+		impl$(<$generic>)? Readable for $type$(<$generic>)?
+		$(where
+			$generic: Readable,)?
+		{
+			fn read_from(buf: &mut impl Buf) -> ReadResult<Self> {
+				Ok(Self(<$inner>::read_from(buf)?))
+			}
+		}
+
+		impl$(<$generic>)? Writable for $type$(<$generic>)?
+		$(where
+			$generic: Writable,)?
+		{
+			fn write_to(&self, buf: &mut impl BufMut) -> WriteResult {
+				self.0.write_to(buf)?;
+
+				Ok(())
+			}
+		}
+	};
+}
+
+/// A value measured in pixels.
+#[derive(Debug, Hash, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Px<Num>(pub Num);
+
+impl<Num> Display for Px<Num>
+where
+	Num: Display,
+{
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{} px", self.0)
+	}
+}
+
+impl_xrbk_traits!(Px<Num>(Num));
+
+/// A value measured in millimeters.
+#[derive(Debug, Hash, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Mm<Num>(pub Num);
+
+impl<Num> Display for Mm<Num>
+where
+	Num: Display,
+{
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{} mm", self.0)
+	}
+}
+
+impl_xrbk_traits!(Mm<Num>(Num));
+
+/// A value measured in milliseconds.
+#[derive(Debug, Hash, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Ms<Num>(pub Num);
+
+impl<Num> Display for Ms<Num>
+where
+	Num: Display,
+{
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{} ms", self.0)
+	}
+}
+
+impl_xrbk_traits!(Ms<Num>(Num));
+
+/// A value measured in hertz.
+#[derive(Debug, Hash, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Hz<Num>(pub Num);
+
+impl<Num> Display for Hz<Num>
+where
+	Num: Display,
+{
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{} Hz", self.0)
+	}
+}
+
+impl_xrbk_traits!(Hz<Num>(Num));
+
+/// A value measured as a percentage from 0% to 100%.
+#[derive(Debug, Hash, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct Percentage(u8);
+
+impl Display for Percentage {
+	fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+		write!(f, "{}%", self.0)
+	}
+}
+
+impl Percentage {
+	/// Creates a new percentage.
+	///
+	/// # Errors
+	/// Return a [`ValueOutOfBounds`] error if the `percentage > 100`.
+	pub const fn new(percentage: u8) -> Result<Self, ValueOutOfBounds<u8>> {
+		match percentage {
+			percentage if percentage <= 100 => Ok(Self(percentage)),
+
+			other => Err(ValueOutOfBounds {
+				min: 0,
+				max: 100,
+				found: other,
+			}),
+		}
+	}
+
+	/// Creates a new percentage without ensuring it is has the right bounds.
+	///
+	/// # Safety
+	/// Callers of this function must ensure that the given percentage satisfies
+	/// the bounds `0 <= percentage <= 100`. Creating a [`Percentage`] with a
+	/// value greater than 100 is Undefined Behavior.
+	#[must_use]
+	pub const unsafe fn new_unchecked(percentage: u8) -> Self {
+		Self(percentage)
+	}
+
+	/// Returns the wrapped percentage value.
+	#[must_use]
+	pub const fn unwrap(self) -> u8 {
+		self.0
+	}
+}
+
+impl_xrbk_traits!(Percentage(u8));

--- a/src/x11/event.rs
+++ b/src/x11/event.rs
@@ -12,6 +12,7 @@
 use crate::{
 	atom::Atom,
 	set::WindowConfigMask,
+	unit::Px,
 	Button,
 	CurrentableTime,
 	Drawable,
@@ -25,12 +26,11 @@ use crate::{
 	Timestamp,
 	Window,
 };
-
-use bitflags::bitflags;
 use xrbk::{Buf, ConstantX11Size, ReadResult, Readable, ReadableWithContext, X11Size};
 
-use xrbk_macro::{derive_xrb, ConstantX11Size, Readable, Writable, X11Size};
+use bitflags::bitflags;
 
+use xrbk_macro::{derive_xrb, ConstantX11Size, Readable, Writable, X11Size};
 extern crate self as xrb;
 
 derive_xrb! {
@@ -1403,7 +1403,7 @@ derive_xrb! {
 		/// This is zero for [`WindowClass::InputOnly`] windows.
 		///
 		/// [`WindowClass::InputOnly`]: crate::WindowClass::InputOnly
-		pub border_width: u16,
+		pub border_width: Px<u16>,
 
 		/// Whether [`MapWindow`] and [`ConfigureWindow`] requests on the newly
 		/// created `window` should override a [`SUBSTRUCTURE_REDIRECT`] on the
@@ -1700,7 +1700,7 @@ derive_xrb! {
 		/// This is zero for [`WindowClass::InputOnly`] windows.
 		///
 		/// [`WindowClass::InputOnly`]: crate::WindowClass::InputOnly
-		pub border_width: u16,
+		pub border_width: Px<u16>,
 
 		/// Whether [`MapWindow`] and [`ConfigureWindow`] requests on the
 		/// configured `window` should override a [`SUBSTRUCTURE_REDIRECT`] on
@@ -1863,12 +1863,12 @@ derive_xrb! {
 		/// resize the `window` to.
 		///
 		/// [`ConfigureWindow` request]: super::request::ConfigureWindow
-		pub width: u16,
+		pub width: Px<u16>,
 		/// The height which the [`ConfigureWindow` request] is attempting to
 		/// resize the `window` to.
 		///
 		/// [`ConfigureWindow` request]: super::request::ConfigureWindow
-		pub height: u16,
+		pub height: Px<u16>,
 		[_; ..],
 	}
 }


### PR DESCRIPTION
This both makes it clearer what units something is measured in, as well as makes the API more type safe: you can't accidentally use a value using millimeters as units for something measured in pixels.

Closes #88.