### PR TITLE
Rename `Color` to `ColorId`

### DIFF
--- a/src/common/set/attribute.rs
+++ b/src/common/set/attribute.rs
@@ -4,7 +4,7 @@
 
 use super::__bool;
 use crate::{
-	visual::Color,
+	visual::ColorId,
 	BitGravity,
 	Colormap,
 	CopyableFromParent,
@@ -83,7 +83,7 @@ pub type ColormapAttribute = CopyableFromParent<Colormap>;
 /// |[`window_gravity`]        |[`NorthWest`]|[`InputOutput`] and [`InputOnly`]|
 /// |[`maintain_contents`]     |[`NotUseful`]      |[`InputOutput`] only       |
 /// |[`maintained_planes`]     |`0x_ffff_ffff`     |[`InputOutput`] only       |
-/// |[`maintenance_fallback_color`]|[`Color::ZERO`]|[`InputOutput`] only       |
+/// |[`maintenance_fallback_color`]|[`ColorId::ZERO`]|[`InputOutput`] only     |
 /// |[`override_redirect`]     |`false`      |[`InputOutput`] and [`InputOnly`]|
 /// |[`maintain_windows_under`]|`false`            |[`InputOutput`] only       |
 /// |[`event_mask`]           |[`empty()`][e]|[`InputOutput`] and [`InputOnly`]|
@@ -131,17 +131,17 @@ pub struct Attributes {
 	mask: AttributesMask,
 
 	background_pixmap: Option<BackgroundPixmap>,
-	background_color: Option<Color>,
+	background_color: Option<ColorId>,
 
 	border_pixmap: Option<BorderPixmap>,
-	border_color: Option<Color>,
+	border_color: Option<ColorId>,
 
 	bit_gravity: Option<__BitGravity>,
 	window_gravity: Option<__WindowGravity>,
 
 	maintain_contents: Option<MaintainContents>,
 	maintained_planes: Option<u32>,
-	maintenance_fallback_color: Option<Color>,
+	maintenance_fallback_color: Option<ColorId>,
 
 	override_redirect: Option<__bool>,
 	maintain_windows_under: Option<__bool>,
@@ -179,17 +179,17 @@ pub struct AttributesBuilder {
 	mask: AttributesMask,
 
 	background_pixmap: Option<BackgroundPixmap>,
-	background_color: Option<Color>,
+	background_color: Option<ColorId>,
 
 	border_pixmap: Option<BorderPixmap>,
-	border_color: Option<Color>,
+	border_color: Option<ColorId>,
 
 	bit_gravity: Option<BitGravity>,
 	window_gravity: Option<WindowGravity>,
 
 	maintain_contents: Option<MaintainContents>,
 	maintained_planes: Option<u32>,
-	maintenance_fallback_color: Option<Color>,
+	maintenance_fallback_color: Option<ColorId>,
 
 	override_redirect: Option<bool>,
 	maintain_windows_under: Option<bool>,
@@ -312,7 +312,7 @@ impl AttributesBuilder {
 	///
 	/// [window]: crate::Window
 	/// [`background_pixmap`]: AttributesBuilder::background_pixmap
-	pub fn background_color(&mut self, background_color: Color) -> &mut Self {
+	pub fn background_color(&mut self, background_color: ColorId) -> &mut Self {
 		if self.background_color.is_none() {
 			self.x11_size += 4;
 		}
@@ -358,7 +358,7 @@ impl AttributesBuilder {
 	/// [window]: crate::Window
 	///
 	/// [`border_pixmap`]: AttributesBuilder::border_pixmap
-	pub fn border_color(&mut self, border_color: Color) -> &mut Self {
+	pub fn border_color(&mut self, border_color: ColorId) -> &mut Self {
 		if self.border_color.is_none() {
 			self.x11_size += 4;
 		}
@@ -446,7 +446,7 @@ impl AttributesBuilder {
 	///
 	/// [`maintain_contents`]: Attributes::maintain_contents
 	/// [`maintain_windows_under`]: Attributes::maintain_windows_under
-	pub fn maintenance_fallback_color(&mut self, maintenance_fallback_color: Color) -> &mut Self {
+	pub fn maintenance_fallback_color(&mut self, maintenance_fallback_color: ColorId) -> &mut Self {
 		if self.maintenance_fallback_color.is_none() {
 			self.x11_size += 4;
 		}
@@ -622,7 +622,7 @@ impl Attributes {
 		clippy::missing_const_for_fn,
 		reason = "const is omitted for API uniformity with the other methods and sets"
 	)]
-	pub fn background_color(&self) -> Option<&Color> {
+	pub fn background_color(&self) -> Option<&ColorId> {
 		self.background_color.as_ref()
 	}
 
@@ -658,7 +658,7 @@ impl Attributes {
 		clippy::missing_const_for_fn,
 		reason = "const is omitted for API uniformity with the other methods and sets"
 	)]
-	pub fn border_color(&self) -> Option<&Color> {
+	pub fn border_color(&self) -> Option<&ColorId> {
 		self.border_color.as_ref()
 	}
 
@@ -741,7 +741,7 @@ impl Attributes {
 		clippy::missing_const_for_fn,
 		reason = "const is omitted for API uniformity with the other methods and sets"
 	)]
-	pub fn maintenance_fallback_color(&self) -> Option<&Color> {
+	pub fn maintenance_fallback_color(&self) -> Option<&ColorId> {
 		self.maintenance_fallback_color.as_ref()
 	}
 

--- a/src/common/set/graphics_options.rs
+++ b/src/common/set/graphics_options.rs
@@ -7,7 +7,7 @@ use xrbk_macro::{ConstantX11Size, Readable, Writable, X11Size};
 use crate::{
 	set::{__Px, __bool, __u8},
 	unit::Px,
-	visual::Color,
+	visual::ColorId,
 	Font,
 	Pixmap,
 };
@@ -283,8 +283,8 @@ pub type ClipMask = Option<Pixmap>;
 /// |-------------------------|---------------------------------------------|
 /// |[`function`]             |[`Function::Copy`]                           |
 /// |[`plane_mask`]           |`0xffff_ffff`                                |
-/// |[`foreground_color`]     |[`Color::ZERO`]                              |
-/// |[`background_color`]     |[`Color::ONE`]                               |
+/// |[`foreground_color`]     |[`ColorId::ZERO`]                            |
+/// |[`background_color`]     |[`ColorId::ONE`]                             |
 /// |[`line_width`]           |[`LineWidth::Thin`]                          |
 /// |[`line_style`]           |[`LineStyle::Solid`]                         |
 /// |[`cap_style`]            |[`CapStyle::Butt`]                           |
@@ -339,8 +339,8 @@ pub struct GraphicsOptions {
 
 	plane_mask: Option<u32>,
 
-	foreground_color: Option<Color>,
-	background_color: Option<Color>,
+	foreground_color: Option<ColorId>,
+	background_color: Option<ColorId>,
 
 	line_width: Option<__LineWidth>,
 
@@ -399,8 +399,8 @@ pub struct GraphicsOptionsBuilder {
 
 	plane_mask: Option<u32>,
 
-	foreground_color: Option<Color>,
-	background_color: Option<Color>,
+	foreground_color: Option<ColorId>,
+	background_color: Option<ColorId>,
 
 	line_width: Option<LineWidth>,
 
@@ -571,7 +571,7 @@ impl GraphicsOptionsBuilder {
 	/// See [`GraphicsOptions::foreground_color`] for more information.
 	///
 	/// [foreground color]: GraphicsOptions::foreground_color
-	pub fn foreground_color(&mut self, foreground_color: Color) -> &mut Self {
+	pub fn foreground_color(&mut self, foreground_color: ColorId) -> &mut Self {
 		if self.foreground_color.is_none() {
 			self.x11_size += 4;
 		}
@@ -586,7 +586,7 @@ impl GraphicsOptionsBuilder {
 	/// See [`GraphicsOptions::background_color`] for more information.
 	///
 	/// [background color]: GraphicsOptions::background_color
-	pub fn background_color(&mut self, background_color: Color) -> &mut Self {
+	pub fn background_color(&mut self, background_color: ColorId) -> &mut Self {
 		if self.background_color.is_none() {
 			self.x11_size += 4;
 		}
@@ -910,7 +910,7 @@ impl GraphicsOptions {
 	///
 	/// See [`Function`] for information on each function and its meaning.
 	///
-	/// [color]: Color
+	/// [color]: ColorId
 	#[must_use]
 	pub fn function(&self) -> Option<&Function> {
 		self.function.as_ref().map(|__Function(function)| function)
@@ -928,12 +928,12 @@ impl GraphicsOptions {
 
 	/// The foreground color used in graphics operations.
 	#[must_use]
-	pub const fn foreground_color(&self) -> Option<&Color> {
+	pub const fn foreground_color(&self) -> Option<&ColorId> {
 		self.foreground_color.as_ref()
 	}
 	/// The background color used in graphics operations.
 	#[must_use]
-	pub const fn background_color(&self) -> Option<&Color> {
+	pub const fn background_color(&self) -> Option<&ColorId> {
 		self.background_color.as_ref()
 	}
 

--- a/src/common/visual.rs
+++ b/src/common/visual.rs
@@ -58,13 +58,13 @@ use xrbk_macro::{derive_xrb, new, unwrap, ConstantX11Size, Readable, Wrap, Writa
 	Readable,
 	Writable,
 )]
-pub struct Color(u32);
+pub struct ColorId(u32);
 
-impl Color {
-	/// A `Color` where all bits are zero: `0x0000_0000`.
+impl ColorId {
+	/// A `ColorId` where all bits are zero: `0x0000_0000`.
 	pub const ZERO: Self = Self(0x0000_0000);
 
-	/// A `Color` with a value of `1`.
+	/// A `ColorId` with a value of `1`.
 	pub const ONE: Self = Self(1);
 }
 
@@ -73,6 +73,7 @@ impl Color {
 /// Each of the channels is a `u16` value, where `0` is the minimum intensity
 /// and `65535` is the maximum intensity. The X server scales the values to
 /// match the display hardware.
+#[doc(alias("Color", "Rgb"))]
 #[derive(
 	Copy,
 	Clone,
@@ -333,8 +334,8 @@ derive_xrb! {
 		pub root: Window,
 		pub default_colormap: Colormap,
 
-		pub white: Color,
-		pub black: Color,
+		pub white: ColorId,
+		pub black: ColorId,
 
 		pub current_input_masks: EventMask,
 

--- a/src/message.rs
+++ b/src/message.rs
@@ -102,7 +102,7 @@ pub trait Request: X11Size + Writable {
 	///
 	/// ```
 	/// use xrbk_macro::derive_xrb;
-	/// use xrb::{ColorChannelMask, Colormap, visual::Color, String8};
+	/// use xrb::{ColorChannelMask, Colormap, visual::ColorId, String8};
 	///
 	/// derive_xrb! {
 	///     #[derive(Debug, Hash, PartialEq, Eq, Readable, Writable, X11Size)]
@@ -111,7 +111,7 @@ pub trait Request: X11Size + Writable {
 	///         pub color_channel_mask: ColorChannelMask,
 	///
 	///         pub colormap: Colormap,
-	///         pub color: Color,
+	///         pub color: ColorId,
 	///
 	///         #[allow(clippy::cast_possible_truncation)]
 	///         let name_len: u16 = name => name.len() as u16,


### PR DESCRIPTION
This makes it clearer what the usage of `ColorId` is: you can't use it to get an actual RGB color, but it is used to refer to a certain color.

Fixes #91.